### PR TITLE
Accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "dexie": "^3.2.4"
             },
             "devDependencies": {
+                "@axe-core/playwright": "^4.7.3",
                 "@playwright/test": "^1.37.1",
                 "@sveltejs/adapter-cloudflare": "^2.3.3",
                 "@sveltejs/kit": "^1.22.6",
@@ -61,6 +62,18 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@axe-core/playwright": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.7.3.tgz",
+            "integrity": "sha512-v2PRgAyGvop7bamrTpNJtc5b1R7giAPnMzZXrS/VDZBCY5+uwVYtCNgDvBsqp5P1QMZxUMoBN+CERJUTMjFN0A==",
+            "dev": true,
+            "dependencies": {
+                "axe-core": "^4.7.0"
+            },
+            "peerDependencies": {
+                "playwright-core": ">= 1.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -3316,6 +3329,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/axe-core": {
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
+            "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
     },
     "devDependencies": {
+        "@axe-core/playwright": "^4.7.3",
         "@playwright/test": "^1.37.1",
         "@sveltejs/adapter-cloudflare": "^2.3.3",
         "@sveltejs/kit": "^1.22.6",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,13 @@
 import { expect, test } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
 
 test('index page has expected h1', async ({ page }) => {
   await page.goto('/');
   expect(await page.textContent('h1')).toBe('helth app');
 });
+
+test('home page is accessible', async ({ page }) => {
+  await page.goto('/');
+  const a11yResults = await new AxeBuilder({ page }).analyze();
+  expect(a11yResults.violations).toEqual([]);
+})


### PR DESCRIPTION
Addressing #99 by incorporating `@axe-core/playwright` package which currently gives tons of errors back, especially due to toast notifications like the PWA notification and others.